### PR TITLE
add futures to pipfile so it works in 2.7

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,3 +1,6 @@
 [[source]]
 url = "https://pypi.python.org/simple"
 verify_ssl = true
+
+[packages]
+futures = "*"


### PR DESCRIPTION
When running the test_utils.py from pipenv on windows it fails because it can't find the futures in this package.  test_utils.py did run fine before background was implemented.  The test only outputs this error in 2.7 since it's included with 3.4+.